### PR TITLE
Forcing UTF-8 rendering

### DIFF
--- a/app/views/mailpeek/mail/index.json.jbuilder
+++ b/app/views/mailpeek/mail/index.json.jbuilder
@@ -8,12 +8,12 @@ json.emails(@emails) do |email|
   if email.body.parts.empty?
     parts.push(
       type: email.content_type =~ /plain/ ? 'text' : 'html',
-      content: email.body.decoded)
+      content: email.body.decoded.force_encoding('utf-8'))
   else
     email.body.parts.each do |part|
       parts.push(
         type: part.content_type =~ /plain/ ? 'text' : 'html',
-        content: part.body.decoded)
+        content: part.body.decoded.force_encoding('utf-8'))
     end
   end
 


### PR DESCRIPTION
Slim templates used by ActionMailer have an issue where line breaks occur in unintended places.

The proposed [workaround](https://github.com/slim-template/slim/issues/123) I have seen for this is to force the layout to UTF-8 by adding a data-force-encoding attribute with a UTF-8 character to the mailer layout:

```
doctype html
html
  head
  body data-force-encoding='✓'
    = yield
```

Is this commit reasonable to account for that?  Otherwise an 'Encoding::UndefinedConversionError "\xE2" from ASCII-8BIT to UTF-8' is thrown.  Maybe it should be in a configuration to account for other languages?
